### PR TITLE
All day event ends at the beginning of the next day

### DIFF
--- a/src/ics.ts
+++ b/src/ics.ts
@@ -29,6 +29,8 @@ export const generateIcs = ({
   const currentDate = new Date();
   const eventDateFrom = new Date(from);
   const eventDateTo = new Date(to);
+  // all day event ends at the beginning of the next day
+  eventDateTo.setDate(eventDateTo.getDate() + 1);
   return `BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//everything-ics//everything-ics//EN

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -89,6 +89,7 @@ describe("POST /ics", () => {
     expect(body).toContain("VCALENDAR");
     expect(body).toContain(`SUMMARY:${title}`);
     expect(body).toContain(`DTSTART:20230407`);
+    expect(body).toContain(`DTEND:20230416`);
     expect(body).toContain(`URL:${url}`);
   });
 

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -89,7 +89,7 @@ describe("POST /ics", () => {
     expect(body).toContain("VCALENDAR");
     expect(body).toContain(`SUMMARY:${title}`);
     expect(body).toContain(`DTSTART:20230407`);
-    expect(body).toContain(`DTEND:20230416`);
+    expect(body).toContain(`DTEND:20230417`);
     expect(body).toContain(`URL:${url}`);
   });
 
@@ -106,7 +106,7 @@ describe("POST /ics", () => {
     expect(res.status).toBe(200);
     const body = await res.text();
     expect(body).toContain(`DTSTART:20230407`);
-    expect(body).toContain(`DTEND:20230407`);
+    expect(body).toContain(`DTEND:20230408`);
   });
 
   it("should be 301 when from and to are same date though multiple date", async () => {


### PR DESCRIPTION
On the macOS Calendar app, multiple dates event is shortened by 1 day.
This PR will fix the problem.