### PR TITLE
fix: change ics method from `GET` to `POST`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,7 @@ app.get("/ics/download", async (context) => {
   }
   return context.text(ics, 200, {
     "Content-Type": "text/calendar; charset=utf8",
+    "Content-Disposition": 'attachment; filename="calendar.ics"',
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,14 +65,12 @@ app.get("/ics", async (context) => {
   return context.html(htmlContent);
 });
 
-app.post("/ics", async (context) => {
-  const {
-    title,
-    from,
-    to = from,
-    url,
-    isMultipleDates = "0",
-  } = await context.req.parseBody();
+app.get("/ics/download", async (context) => {
+  const title = context.req.query("title");
+  const from = context.req.query("from");
+  const to = context.req.query("to") || from;
+  const url = context.req.query("url");
+  const isMultipleDates = context.req.query("isMultipleDates") || "0";
   if (
     typeof title !== "string" ||
     typeof from !== "string" ||

--- a/src/pages/edit.ts
+++ b/src/pages/edit.ts
@@ -81,7 +81,7 @@ const content = ({ title, candidateDates, url }: Event, error: string) => {
   return html`
     <section>
       ${error ? buildErrorMessage(error) : ""}
-      <form action="/ics" method="POST">
+      <form action="/ics/download" method="GET">
         <div>
           <label for="title" class="c-title--label">Title</label>
           <input

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -71,19 +71,18 @@ describe("GET /ics", () => {
   });
 });
 
-describe("POST /ics", () => {
+describe("GET /ics/download", () => {
   it("should be generate ics when pass Title, From and To", async () => {
     const title = "Birthday";
     const url = `${exampleServer}/date`;
-    const formData = new FormData();
-    formData.append("title", title);
-    formData.append("from", "2023-04-07T12:00:00.000");
-    formData.append("to", "2023-04-16T12:00:00.000");
-    formData.append("isMultipleDates", "1");
-    formData.append("url", url);
-    const req = new Request(`${appServer}/ics`, {
-      method: "POST",
-      body: formData,
+    const urlParams = new URLSearchParams();
+    urlParams.append("title", title);
+    urlParams.append("from", "2023-04-07T12:00:00.000");
+    urlParams.append("to", "2023-04-16T12:00:00.000");
+    urlParams.append("isMultipleDates", "1");
+    urlParams.append("url", url);
+    const req = new Request(`${appServer}/ics/download?${urlParams}`, {
+      method: "GET",
     });
     const res = await app.request(req);
     expect(res.status).toBe(200);
@@ -96,13 +95,12 @@ describe("POST /ics", () => {
   });
 
   it("should be generate ics when it is not multiple date", async () => {
-    const formData = new FormData();
-    formData.append("title", "Birthday");
-    formData.append("from", "2023-04-07T12:00:00.000");
-    formData.append("url", `${exampleServer}/date`);
-    const req = new Request(`${appServer}/ics`, {
-      method: "POST",
-      body: formData,
+    const urlParams = new URLSearchParams();
+    urlParams.append("title", "Birthday");
+    urlParams.append("from", "2023-04-07T12:00:00.000");
+    urlParams.append("url", `${exampleServer}/date`);
+    const req = new Request(`${appServer}/ics/download?${urlParams}`, {
+      method: "GET",
     });
     const res = await app.request(req);
     expect(res.status).toBe(200);
@@ -112,30 +110,28 @@ describe("POST /ics", () => {
   });
 
   it("should be 301 when from and to are same date though multiple date", async () => {
-    const formData = new FormData();
-    formData.append("title", "Birthday");
-    formData.append("from", "2023-04-07T12:00:00.000");
-    formData.append("to", "2023-04-07T12:00:00.000");
-    formData.append("url", `${exampleServer}/date`);
-    formData.append("isMultipleDates", "1");
-    const req = new Request(`${appServer}/ics`, {
-      method: "POST",
-      body: formData,
+    const urlParams = new URLSearchParams();
+    urlParams.append("title", "Birthday");
+    urlParams.append("from", "2023-04-07T12:00:00.000");
+    urlParams.append("to", "2023-04-07T12:00:00.000");
+    urlParams.append("url", `${exampleServer}/date`);
+    urlParams.append("isMultipleDates", "1");
+    const req = new Request(`${appServer}/ics/download?${urlParams}`, {
+      method: "GET",
     });
     const res = await app.request(req);
     expect(res.status).toBe(301);
   });
 
   it("should be 301 when From is after To", async () => {
-    const formData = new FormData();
-    formData.append("title", "Birthday");
-    formData.append("from", "2023-04-10T12:00:00.000");
-    formData.append("to", "2023-04-08T12:00:00.000");
-    formData.append("isMultipleDates", "1");
-    formData.append("url", `${exampleServer}/date`);
-    const req = new Request(`${appServer}/ics`, {
-      method: "POST",
-      body: formData,
+    const urlParams = new URLSearchParams();
+    urlParams.append("title", "Birthday");
+    urlParams.append("from", "2023-04-10T12:00:00.000");
+    urlParams.append("to", "2023-04-08T12:00:00.000");
+    urlParams.append("isMultipleDates", "1");
+    urlParams.append("url", `${exampleServer}/date`);
+    const req = new Request(`${appServer}/ics/download?${urlParams}`, {
+      method: "GET",
     });
     const res = await app.request(req);
     expect(res.status).toBe(301);


### PR DESCRIPTION
Fixed an error when used with Chrome on mobile.
This is because the GET method is called by the Safari Component when generating the iCS file.